### PR TITLE
syntax change in symfony 2.6 for defining factory service

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -23,12 +23,9 @@
         </service>
 
         <!-- Google Client -->
-        <service
-            id="isometriks_google_api.client"
-            class="%isometriks_google_api.client.class%"
-            factory-service="isometriks_google_api.client_factory"
-            factory-method="createClient"
-        />
+        <service id="isometriks_google_api.client" class="%isometriks_google_api.client.class%">
+            <factory service="isometriks_google_api.client_factory" method="createClient" />
+        </service>
 
         <!-- Scope Manager -->
         <service id="isometriks_google_api.scope_manager" class="%isometriks_google_api.scope_manager.class%">


### PR DESCRIPTION
The old syntax in service.xml to identify the service and method of a factory were deprecated in Symfony 2.6 and removed in Symfony 3.0.

change from

```
<service factory-service="" factory-method="" />
```

to

```
<service>
    <factory service="" method="">
</service>
```

https://github.com/symfony/symfony/blob/2.7/UPGRADE-3.0.md#dependencyinjection
