### PR TITLE
A session cookie is created when not needed

### DIFF
--- a/Storage/SessionStorage.php
+++ b/Storage/SessionStorage.php
@@ -22,7 +22,11 @@ class SessionStorage implements StorageInterface
 
     public function hasToken()
     {
-        return $this->session->has(self::TOKEN_KEY);
+        if ($this->session->isStarted()) {
+            return $this->session->has(self::TOKEN_KEY);
+        } else {
+            return false;
+        }
     }
 
     public function removeToken()


### PR DESCRIPTION
When using a firewall with `stateless: true` this bundle will end up creating a session and causing a cookie to be created even when no token exists to be set.

The cause is because accessing the Symfony session creates a session if it has not yet been created, even when just checking if the session has a key in it.

The proposed fix is to check if the session has been started in `SessionStorage:hasToken()` before trying to access it.
